### PR TITLE
Run x64 macOS tests on macOS-15-intel

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
     tags: '*'
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -21,18 +21,14 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        arch:
-          - 'default'
         include:
           - os: macOS-15-intel
-            arch: x64
             version: '1'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - run: make -j
         env:
           CC: gcc

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,16 +20,16 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-13
+          - macOS-latest
         arch:
-          - x64
+          - 'default'
         include:
-          - os: macOS-latest
-            arch: aarch64
+          - os: macOS-15-intel
+            arch: x64
             version: '1'
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
Also turn around the order of inclusion: Make native binaries on the default images the standard cases, and additionally include a x64 binary on Intel Mac (`macOS-15-intel` since `macOS-13-intel` was retired: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).